### PR TITLE
Increase code selection contrast

### DIFF
--- a/style/variables.css
+++ b/style/variables.css
@@ -430,3 +430,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   border-top-color: var(--jp-night-green);
   border-top-width: 3px;
 }
+
+.CodeMirror-selected {
+  background-color: #1e4273 !important;
+}


### PR DESCRIPTION
Fix https://github.com/martinRenou/jupyterlab-night/issues/5

![selection](https://user-images.githubusercontent.com/21197331/165335379-4f83ddab-dcef-4c2a-9465-3a5b1a567e00.png)

This is again inspired from the Github color palette 